### PR TITLE
feat: generate visitor with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ endif()
 
 
 # Call macro to add lexer and grammar to your build dependencies.
-antlr_target(SceneGrammarParser Scene.g4)
+antlr_target(SceneGrammarParser Scene.g4 VISITOR OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/libs/)
 
 # add our project source directories
 include_directories(${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
Eliminate the manual command 
```cmake
# generate the ANTLR components (you have to setup ANTLR, before doing this step)
antlr4 -Dlanguage=Cpp -no-listener -visitor -o libs Scene.g4
```
to generate antlr components (lexer,parser,visitor) into the libs folder. 